### PR TITLE
Doesn't allow nulls parameters on `NotifiableCallback` methods

### DIFF
--- a/library/src/main/java/com/futureworkshops/notifiable/NotifiableManager.java
+++ b/library/src/main/java/com/futureworkshops/notifiable/NotifiableManager.java
@@ -13,7 +13,6 @@ import com.futureworkshops.notifiable.networking.RestManager;
 
 import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 
 /**
  * Created by stelian on 22/03/2016.
@@ -32,12 +31,12 @@ public class NotifiableManager {
      * @return a new {@code NotifiableManager}
      */
     public static NotifiableManager newInstance(@NonNull final String url,
-                                                @NonNull String clientId, @NonNull String clientSecret) {
+            @NonNull String clientId, @NonNull String clientSecret) {
         return new NotifiableManager(url, clientId, clientSecret);
     }
 
     private NotifiableManager(@NonNull final String url,
-                              @NonNull String clientId, @NonNull String clientSecret) {
+            @NonNull String clientId, @NonNull String clientSecret) {
         mRestManager = new RestManager(url, clientId, clientSecret);
     }
 
@@ -51,127 +50,121 @@ public class NotifiableManager {
      * @param callback    the callback used to deliver the result of the operation
      */
     public void registerAnonymousDevice(@NonNull final String deviceName,
-                                        @NonNull final String deviceToken,
-                                        @NonNull final Locale locale,
-                                        @NonNull String provider,
-                                        @NonNull final NotifiableCallback<NotifiableDevice> callback) {
+            @NonNull final String deviceToken,
+            @NonNull final Locale locale,
+            @NonNull String provider,
+            @NonNull final NotifiableCallback<NotifiableDevice> callback) {
         this.registerAnonymousDevice(deviceName, deviceToken, locale, provider, null, callback);
     }
 
     /**
      * Register a device to receive notifications from the Notifiable server without associating the device with a user.
      *
-     * @param deviceName  the name of the device, can be anything
-     * @param deviceToken the GCM token for this device
-     * @param locale      locale of the device
-     * @param provider    The provider of Cloud Messaging services (typically gcm)
-     * @param customProperties  Set of properties to be associated to the device
-     * @param callback    the callback used to deliver the result of the operation
+     * @param deviceName       the name of the device, can be anything
+     * @param deviceToken      the GCM token for this device
+     * @param locale           locale of the device
+     * @param provider         The provider of Cloud Messaging services (typically gcm)
+     * @param customProperties Set of properties to be associated to the device
+     * @param callback         the callback used to deliver the result of the operation
      */
     public void registerAnonymousDevice(@NonNull final String deviceName,
-                                        @NonNull final String deviceToken,
-                                        @NonNull final Locale locale,
-                                        @NonNull String provider,
-                                        @Nullable HashMap<String, Object> customProperties,
-                                        @NonNull final NotifiableCallback<NotifiableDevice> callback) {
+            @NonNull final String deviceToken,
+            @NonNull final Locale locale,
+            @NonNull String provider,
+            @Nullable HashMap<String, Object> customProperties,
+            @NonNull final NotifiableCallback<NotifiableDevice> callback) {
         mRestManager.registerAnonymousDevice(deviceName, deviceToken, locale, provider, customProperties,
-            new NotifiableCallback<NotifiableDevice>() {
-                @Override
-                public void onSuccess(NotifiableDevice device) {
-                    if (device != null) {
+                new NotifiableCallback<NotifiableDevice>() {
+                    @Override
+                    public void onSuccess(@NonNull NotifiableDevice device) {
                         device.setName(deviceName);
                         device.setToken(deviceToken);
                         device.setLocale(locale);
+                        callback.onSuccess(device);
                     }
-                    callback.onSuccess(device);
-                }
 
-                @Override
-                public void onError(String error) {
-                    callback.onError(error);
-                }
-            });
+                    @Override
+                    public void onError(@NonNull String error) {
+                        callback.onError(error);
+                    }
+                });
     }
 
     /**
      * Register a device to receive notifications from the Notifiable server and associate the device to the given user.
      *
      * @param deviceName the name of the device, can be anything
-     *                   * @param deviceToken the GCM token for this device
+     * @param deviceToken the GCM token for this device
      * @param userAlias  the name of the user you want to associate the device to
      * @param locale     locale of the device
      * @param provider   The provider of Cloud Messaging services (typically gcm)
      * @param callback   the callback used to deliver the result of the operation
      */
     public void registerDevice(@NonNull final String deviceName,
-                               @NonNull final String deviceToken,
-                               @NonNull final String userAlias,
-                               @NonNull final Locale locale,
-                               @NonNull String provider,
-                               @NonNull final NotifiableCallback<NotifiableDevice> callback) {
+            @NonNull final String deviceToken,
+            @NonNull final String userAlias,
+            @NonNull final Locale locale,
+            @NonNull String provider,
+            @NonNull final NotifiableCallback<NotifiableDevice> callback) {
         this.registerDevice(deviceName, deviceToken, userAlias, locale, provider, null, callback);
     }
 
     /**
      * Register a device to receive notifications from the Notifiable server and associate the device to the given user.
      *
-     * @param deviceName the name of the device, can be anything
-     *                   * @param deviceToken the GCM token for this device
-     * @param userAlias  the name of the user you want to associate the device to
-     * @param locale     locale of the device
-     * @param provider   The provider of Cloud Messaging services (typically gcm)
-     * @param customProperties  Set of properties to be associated to the device
-     * @param callback   the callback used to deliver the result of the operation
+     * @param deviceName       the name of the device, can be anything
+     * @param deviceToken the GCM token for this device
+     * @param userAlias        the name of the user you want to associate the device to
+     * @param locale           locale of the device
+     * @param provider         The provider of Cloud Messaging services (typically gcm)
+     * @param customProperties Set of properties to be associated to the device
+     * @param callback         the callback used to deliver the result of the operation
      */
     public void registerDevice(@NonNull final String deviceName,
-                               @NonNull final String deviceToken,
-                               @NonNull final String userAlias,
-                               @NonNull final Locale locale,
-                               @NonNull String provider,
-                               @Nullable HashMap<String, Object> customProperties,
-                               @NonNull final NotifiableCallback<NotifiableDevice> callback) {
+            @NonNull final String deviceToken,
+            @NonNull final String userAlias,
+            @NonNull final Locale locale,
+            @NonNull String provider,
+            @Nullable HashMap<String, Object> customProperties,
+            @NonNull final NotifiableCallback<NotifiableDevice> callback) {
         mRestManager.registerDeviceForUser(deviceName, deviceToken, userAlias, locale, provider, customProperties,
-            new NotifiableCallback<NotifiableDevice>() {
-                @Override
-                public void onSuccess(NotifiableDevice device) {
-                    if (device != null) {
+                new NotifiableCallback<NotifiableDevice>() {
+                    @Override
+                    public void onSuccess(@NonNull NotifiableDevice device) {
                         device.setName(deviceName);
                         device.setUser(userAlias);
                         device.setToken(deviceToken);
                         device.setLocale(locale);
+                        callback.onSuccess(device);
                     }
-                    callback.onSuccess(device);
-                }
 
-                @Override
-                public void onError(String error) {
-                    callback.onError(error);
-                }
-            });
+                    @Override
+                    public void onError(@NonNull String error) {
+                        callback.onError(error);
+                    }
+                });
     }
 
     /**
      * Updates the Locale information of a specif device
      *
-     * @param deviceId  id returned by the server after registering the device
-     * @param locale    locale of the device
-     * @param callback  the callback used to deliver the result of the operation
+     * @param deviceId id returned by the server after registering the device
+     * @param locale   locale of the device
+     * @param callback the callback used to deliver the result of the operation
      */
     public void updateDeviceLocale(@NonNull final String deviceId,
-                                   @NonNull Locale locale,
-                                   @NonNull final NotifiableCallback<NotifiableDevice> callback) {
+            @NonNull Locale locale,
+            @NonNull final NotifiableCallback<NotifiableDevice> callback) {
         mRestManager.updateDeviceLocale(deviceId, locale, new NotifiableCallback<NotifiableDevice>() {
             @Override
-            public void onSuccess(NotifiableDevice device) {
-                if (device != null) {
-                    device.setLocale(locale);
-                    device.setId(Integer.valueOf(deviceId));
-                }
+            public void onSuccess(@NonNull NotifiableDevice device) {
+                device.setLocale(locale);
+                device.setId(Integer.valueOf(deviceId));
                 callback.onSuccess(device);
             }
 
             @Override
-            public void onError(String error) {
+            public void onError(@NonNull String error) {
                 callback.onError(error);
             }
         });
@@ -180,161 +173,157 @@ public class NotifiableManager {
     /**
      * Updates the device token of a registered device
      *
-     * @param userName      the name of the user you want to associate the device to
-     * @param deviceId      id returned by the server after registering the device
-     * @param deviceToken   the GCM token for this device
-     * @param callback      the callback used to deliver the result of the operation
+     * @param userName    the name of the user you want to associate the device to
+     * @param deviceId    id returned by the server after registering the device
+     * @param deviceToken the GCM token for this device
+     * @param callback    the callback used to deliver the result of the operation
      */
     public void updateDeviceToken(@NonNull final String userName,
-                                  @NonNull final String deviceId,
-                                  @NonNull final String deviceToken,
-                                  @NonNull final NotifiableCallback<NotifiableDevice> callback) {
+            @NonNull final String deviceId,
+            @NonNull final String deviceToken,
+            @NonNull final NotifiableCallback<NotifiableDevice> callback) {
 
-        mRestManager.updateDeviceInformation(deviceId, deviceToken, userName, null, null, null,  new NotifiableCallback<NotifiableDevice>() {
-            @Override
-            public void onSuccess(NotifiableDevice device) {
-                if (device != null) {
-                    device.setUser(userName);
-                    device.setToken(deviceToken);
-                    device.setId(Integer.valueOf(deviceId));
-                }
-                callback.onSuccess(device);
-            }
+        mRestManager.updateDeviceInformation(deviceId, deviceToken, userName, null, null, null, new
+                NotifiableCallback<NotifiableDevice>() {
+                    @Override
+                    public void onSuccess(@NonNull NotifiableDevice device) {
+                        device.setUser(userName);
+                        device.setToken(deviceToken);
+                        device.setId(Integer.valueOf(deviceId));
+                        callback.onSuccess(device);
+                    }
 
-            @Override
-            public void onError(String error) {
-                callback.onError(error);
-            }
-        });
+                    @Override
+                    public void onError(@NonNull String error) {
+                        callback.onError(error);
+                    }
+                });
     }
 
     /**
      * Updates the device token of a registered device
      *
-     * @param deviceId      id returned by the server after registering the device
-     * @param deviceToken   the GCM token for this device
-     * @param callback      the callback used to deliver the result of the operation
+     * @param deviceId    id returned by the server after registering the device
+     * @param deviceToken the GCM token for this device
+     * @param callback    the callback used to deliver the result of the operation
      */
     public void updateAnonymousDeviceToken(@NonNull final String deviceId,
-                                           @NonNull final String deviceToken,
-                                           @NonNull final NotifiableCallback<NotifiableDevice> callback) {
+            @NonNull final String deviceToken,
+            @NonNull final NotifiableCallback<NotifiableDevice> callback) {
 
-        mRestManager.updateDeviceInformation(deviceId, deviceToken, null, null, null, null, new NotifiableCallback<NotifiableDevice>() {
-            @Override
-            public void onSuccess(NotifiableDevice device) {
-                if (device != null) {
-                    device.setToken(deviceToken);
-                    device.setId(Integer.valueOf(deviceId));
-                }
-                callback.onSuccess(device);
-            }
+        mRestManager.updateDeviceInformation(deviceId, deviceToken, null, null, null, null, new
+                NotifiableCallback<NotifiableDevice>() {
+                    @Override
+                    public void onSuccess(@NonNull NotifiableDevice device) {
+                        device.setToken(deviceToken);
+                        device.setId(Integer.valueOf(deviceId));
+                        callback.onSuccess(device);
+                    }
 
-            @Override
-            public void onError(String error) {
-                callback.onError(error);
-            }
-        });
+                    @Override
+                    public void onError(@NonNull String error) {
+                        callback.onError(error);
+                    }
+                });
     }
 
     /**
      * Updates the name of a registered device
      *
-     * @param userName      the name of the user you want to associate the device to
-     * @param deviceId      id returned by the server after registering the device
-     * @param deviceName    the name of the device, can be anything
-     * @param callback      the callback used to deliver the result of the operation
+     * @param userName   the name of the user you want to associate the device to
+     * @param deviceId   id returned by the server after registering the device
+     * @param deviceName the name of the device, can be anything
+     * @param callback   the callback used to deliver the result of the operation
      */
     public void updateDeviceName(@NonNull final String userName,
-                                 @NonNull final String deviceId,
-                                 @NonNull final String deviceName,
-                                 @NonNull final NotifiableCallback<NotifiableDevice> callback) {
+            @NonNull final String deviceId,
+            @NonNull final String deviceName,
+            @NonNull final NotifiableCallback<NotifiableDevice> callback) {
 
-        mRestManager.updateDeviceInformation(deviceId, null, userName, deviceName, null, null, new NotifiableCallback<NotifiableDevice>() {
-            @Override
-            public void onSuccess(NotifiableDevice device) {
-                if (device != null) {
-                    device.setUser(userName);
-                    device.setName(deviceName);
-                    device.setId(Integer.valueOf(deviceId));
-                }
-                callback.onSuccess(device);
-            }
+        mRestManager.updateDeviceInformation(deviceId, null, userName, deviceName, null, null, new
+                NotifiableCallback<NotifiableDevice>() {
+                    @Override
+                    public void onSuccess(@NonNull NotifiableDevice device) {
+                        device.setUser(userName);
+                        device.setName(deviceName);
+                        device.setId(Integer.valueOf(deviceId));
+                        callback.onSuccess(device);
+                    }
 
-            @Override
-            public void onError(String error) {
-                callback.onError(error);
-            }
-        });
+                    @Override
+                    public void onError(@NonNull String error) {
+                        callback.onError(error);
+                    }
+                });
     }
 
     /**
      * Updates the name of a registered device
      *
-     * @param deviceId      id returned by the server after registering the device
-     * @param deviceName    the name of the device, can be anything
-     * @param callback      the callback used to deliver the result of the operation
+     * @param deviceId   id returned by the server after registering the device
+     * @param deviceName the name of the device, can be anything
+     * @param callback   the callback used to deliver the result of the operation
      */
     public void updateAnonymousDeviceName(@NonNull final String deviceId, @NonNull final String deviceName,
-                                          @NonNull final NotifiableCallback<NotifiableDevice> callback) {
+            @NonNull final NotifiableCallback<NotifiableDevice> callback) {
 
-        mRestManager.updateDeviceInformation(deviceId, null, null, deviceName, null, null, new NotifiableCallback<NotifiableDevice>() {
-            @Override
-            public void onSuccess(NotifiableDevice device) {
-                if (device != null) {
-                    device.setName(deviceName);
-                    device.setId(Integer.valueOf(deviceId));
-                }
-                callback.onSuccess(device);
-            }
+        mRestManager.updateDeviceInformation(deviceId, null, null, deviceName, null, null, new
+                NotifiableCallback<NotifiableDevice>() {
+                    @Override
+                    public void onSuccess(@NonNull NotifiableDevice device) {
+                        device.setName(deviceName);
+                        device.setId(Integer.valueOf(deviceId));
+                        callback.onSuccess(device);
+                    }
 
-            @Override
-            public void onError(String error) {
-                callback.onError(error);
-            }
-        });
+                    @Override
+                    public void onError(@NonNull String error) {
+                        callback.onError(error);
+                    }
+                });
     }
 
     /**
      * Update device information. Valid properties are defined in the server app.
      *
-     * @param deviceId   id returned by the server after registering the device
+     * @param deviceId         id returned by the server after registering the device
      * @param customProperties map containing device properties
-     * @param callback   the callback used to deliver the result of the operation
+     * @param callback         the callback used to deliver the result of the operation
      */
-    public void updateDeviceCustomProperties(@NonNull final  String deviceId,
-                                             @NonNull final HashMap<String, Object> customProperties,
-                                             @NonNull final NotifiableCallback<NotifiableDevice> callback) {
-        mRestManager.updateDeviceCustomProperties(deviceId, customProperties, new NotifiableCallback<NotifiableDevice>() {
-            @Override
-            public void onSuccess(NotifiableDevice device) {
-                if (device != null) {
-                    device.setCustomProperties(customProperties);
-                }
-            }
+    public void updateDeviceCustomProperties(@NonNull final String deviceId,
+            @NonNull final HashMap<String, Object> customProperties,
+            @NonNull final NotifiableCallback<NotifiableDevice> callback) {
+        mRestManager.updateDeviceCustomProperties(deviceId, customProperties, new
+                NotifiableCallback<NotifiableDevice>() {
+                    @Override
+                    public void onSuccess(@NonNull NotifiableDevice device) {
+                        device.setCustomProperties(customProperties);
+                        callback.onSuccess(device);
+                    }
 
-            @Override
-            public void onError(String error) {
-                callback.onError(error);
-            }
-        });
+                    @Override
+                    public void onError(@NonNull String error) {
+                        callback.onError(error);
+                    }
+                });
     }
 
     /**
      * Unregister the given device.
      *
-     * @param deviceId  id returned by the server after registering the device
-     * @param callback  the callback used to deliver the result of the operation
+     * @param deviceId id returned by the server after registering the device
+     * @param callback the callback used to deliver the result of the operation
      */
     public void unregisterDevice(@NonNull String deviceId,
-                                 @NonNull final NotifiableCallback<Object> callback) {
+            @NonNull final NotifiableCallback<Object> callback) {
         mRestManager.unregisterToken(deviceId, new NotifiableCallback<Object>() {
             @Override
-            public void onSuccess(Object o) {
+            public void onSuccess(@NonNull Object o) {
                 callback.onSuccess(o);
             }
 
             @Override
-            public void onError(String error) {
+            public void onError(@NonNull String error) {
                 callback.onError(error);
             }
         });
@@ -347,16 +336,17 @@ public class NotifiableManager {
      * @param deviceId       id returned by the server after registering the device
      * @param callback       the callback used to deliver the result of the operation
      */
-    public void markNotificationReceived(@NonNull String notificationId, @NonNull String deviceId, @NonNull final NotifiableCallback<Object> callback) {
+    public void markNotificationReceived(@NonNull String notificationId, @NonNull String deviceId, @NonNull final
+    NotifiableCallback<Object> callback) {
         mRestManager.markNotificationAsReceived(notificationId, deviceId, new NotifiableCallback<Object>() {
 
             @Override
-            public void onSuccess(Object o) {
+            public void onSuccess(@NonNull Object o) {
                 callback.onSuccess(o);
             }
 
             @Override
-            public void onError(String error) {
+            public void onError(@NonNull String error) {
                 callback.onError(error);
             }
         });
@@ -369,16 +359,17 @@ public class NotifiableManager {
      * @param deviceId       id returned by the server after registering the device
      * @param callback       the callback used to deliver the result of the operation
      */
-    public void markNotificationOpened(@NonNull String notificationId, @NonNull String deviceId, @NonNull final NotifiableCallback<Object> callback) {
+    public void markNotificationOpened(@NonNull String notificationId, @NonNull String deviceId, @NonNull final
+    NotifiableCallback<Object> callback) {
         mRestManager.markNotificationAsOpened(notificationId, deviceId, new NotifiableCallback<Object>() {
 
             @Override
-            public void onSuccess(Object o) {
+            public void onSuccess(@NonNull Object o) {
                 callback.onSuccess(o);
             }
 
             @Override
-            public void onError(String error) {
+            public void onError(@NonNull String error) {
                 callback.onError(error);
             }
         });
@@ -393,23 +384,21 @@ public class NotifiableManager {
      * @param callback    the callback used to deliver the result of the operation
      */
     public void unassignDeviceFromUser(@NonNull final String deviceName, @NonNull final String deviceToken,
-                                       @NonNull final NotifiableCallback<NotifiableDevice> callback) {
+            @NonNull final NotifiableCallback<NotifiableDevice> callback) {
         mRestManager.registerAnonymousDevice(deviceName, deviceToken, null, null,
-            new NotifiableCallback<NotifiableDevice>() {
-                @Override
-                public void onSuccess(NotifiableDevice device) {
-                    if (device != null) {
+                new NotifiableCallback<NotifiableDevice>() {
+                    @Override
+                    public void onSuccess(@NonNull NotifiableDevice device) {
                         device.setName(deviceName);
                         device.setToken(deviceToken);
+                        callback.onSuccess(device);
                     }
-                    callback.onSuccess(device);
-                }
 
-                @Override
-                public void onError(String error) {
-                    callback.onError(error);
-                }
-            });
+                    @Override
+                    public void onError(@NonNull String error) {
+                        callback.onError(error);
+                    }
+                });
     }
 
     /**
@@ -422,24 +411,22 @@ public class NotifiableManager {
      * @param callback    the callback used to deliver the result of the operation
      */
     public void assignDeviceToUser(@NonNull final String userName, @NonNull final String deviceName,
-                                   @NonNull final String deviceToken,
-                                   @NonNull final NotifiableCallback<NotifiableDevice> callback) {
+            @NonNull final String deviceToken,
+            @NonNull final NotifiableCallback<NotifiableDevice> callback) {
         mRestManager.registerDeviceForUser(deviceName, deviceToken, userName, null, null,
-            new NotifiableCallback<NotifiableDevice>() {
-                @Override
-                public void onSuccess(NotifiableDevice device) {
-                    if (device != null) {
+                new NotifiableCallback<NotifiableDevice>() {
+                    @Override
+                    public void onSuccess(@NonNull NotifiableDevice device) {
                         device.setName(deviceName);
                         device.setUser(userName);
                         device.setToken(deviceToken);
+                        callback.onSuccess(device);
                     }
-                    callback.onSuccess(device);
-                }
 
-                @Override
-                public void onError(String error) {
-                    callback.onError(error);
-                }
-            });
+                    @Override
+                    public void onError(@NonNull String error) {
+                        callback.onError(error);
+                    }
+                });
     }
 }

--- a/library/src/main/java/com/futureworkshops/notifiable/model/NotifiableCallback.java
+++ b/library/src/main/java/com/futureworkshops/notifiable/model/NotifiableCallback.java
@@ -4,12 +4,14 @@
 
 package com.futureworkshops.notifiable.model;
 
+import android.support.annotation.NonNull;
+
 /**
  * Created by stelian on 22/03/2016.
  */
 public interface NotifiableCallback<S> {
 
-    void onSuccess(S ret);
+    void onSuccess(@NonNull S ret);
 
-    void onError(String error);
+    void onError(@NonNull String error);
 }

--- a/library/src/main/java/com/futureworkshops/notifiable/networking/RestManager.java
+++ b/library/src/main/java/com/futureworkshops/notifiable/networking/RestManager.java
@@ -246,12 +246,12 @@ public class RestManager implements RestAPI {
             final Call<ResponseBody> call = mService.unregisterToken(deviceId, paramObject.toString());
             call.enqueue(new DefaultResponseHandler<>(new NotifiableCallback<ResponseBody>() {
                 @Override
-                public void onSuccess(ResponseBody ret) {
-                    callback.onSuccess(null);
+                public void onSuccess(@NonNull ResponseBody ret) {
+                    callback.onSuccess(new Object());
                 }
 
                 @Override
-                public void onError(String error) {
+                public void onError(@NonNull String error) {
                     callback.onError(error);
                 }
             }));
@@ -273,12 +273,12 @@ public class RestManager implements RestAPI {
             final Call<ResponseBody> call = mService.markNotificationAsOpened(notificationId, paramObject.toString());
             call.enqueue(new DefaultResponseHandler<>(new NotifiableCallback<ResponseBody>() {
                 @Override
-                public void onSuccess(ResponseBody ret) {
-                    callback.onSuccess(null);
+                public void onSuccess(@NonNull ResponseBody ret) {
+                    callback.onSuccess(new Object());
                 }
 
                 @Override
-                public void onError(String error) {
+                public void onError(@NonNull String error) {
                     callback.onError(error);
                 }
             }));
@@ -300,12 +300,12 @@ public class RestManager implements RestAPI {
             final Call<ResponseBody> call = mService.markNotificationAsReceived(notificationId, paramObject.toString());
             call.enqueue(new DefaultResponseHandler<>(new NotifiableCallback<ResponseBody>() {
                 @Override
-                public void onSuccess(ResponseBody ret) {
-                    callback.onSuccess(null);
+                public void onSuccess(@NonNull ResponseBody ret) {
+                    callback.onSuccess(new Object());
                 }
 
                 @Override
-                public void onError(String error) {
+                public void onError(@NonNull String error) {
                     callback.onError(error);
                 }
             }));

--- a/sample-app/src/main/java/com/futureworkshops/notifiable/sample/NotifiableActivity.java
+++ b/sample-app/src/main/java/com/futureworkshops/notifiable/sample/NotifiableActivity.java
@@ -215,14 +215,14 @@ public class NotifiableActivity extends AppCompatActivity {
         mNotifiableManager.markNotificationOpened(String.valueOf(mLatestNotification.getNotificationId()),
             String.valueOf(mDeviceId), new NotifiableCallback<Object>() {
                 @Override
-                public void onSuccess(Object ret) {
+                public void onSuccess(@NonNull Object ret) {
                     showSnackbar("Notification marked as open");
                     mLatestNotification = null;
                     mOpenNotificationButton.setVisibility(View.GONE);
                 }
 
                 @Override
-                public void onError(String error) {
+                public void onError(@NonNull String error) {
                     showSnackbar(error);
                 }
             });
@@ -231,12 +231,12 @@ public class NotifiableActivity extends AppCompatActivity {
     private void updateDeviceToken() {
         final NotifiableCallback<NotifiableDevice> callback = new NotifiableCallback<NotifiableDevice>() {
             @Override
-            public void onSuccess(NotifiableDevice ret) {
+            public void onSuccess(@NonNull NotifiableDevice ret) {
                 showSnackbar("GCM token has been refreshed");
             }
 
             @Override
-            public void onError(String error) {
+            public void onError(@NonNull String error) {
                 showSnackbar(error);
             }
         };
@@ -423,7 +423,7 @@ public class NotifiableActivity extends AppCompatActivity {
                 mCurrentLocale, NotifiableManager.GOOGLE_CLOUD_MESSAGING_PROVIDER,
                 new NotifiableCallback<NotifiableDevice>() {
                     @Override
-                    public void onSuccess(NotifiableDevice ret) {
+                    public void onSuccess(@NonNull NotifiableDevice ret) {
                         mDeviceName = deviceName;
                         mDeviceUser = user;
                         mState = NotifiableStates.REGISTERED_ANONYMOUSLY;
@@ -435,7 +435,7 @@ public class NotifiableActivity extends AppCompatActivity {
                     }
 
                     @Override
-                    public void onError(String error) {
+                    public void onError(@NonNull String error) {
                         mSharedPrefs.edit().putInt(Constants.NOTIFIABLE_DEVICE_ID, -1).apply();
                         showSnackbar(error);
                     }
@@ -445,7 +445,7 @@ public class NotifiableActivity extends AppCompatActivity {
                 mCurrentLocale, NotifiableManager.GOOGLE_CLOUD_MESSAGING_PROVIDER,
                 new NotifiableCallback<NotifiableDevice>() {
                     @Override
-                    public void onSuccess(NotifiableDevice ret) {
+                    public void onSuccess(@NonNull NotifiableDevice ret) {
                         mDeviceUser = user;
                         mDeviceName = deviceName;
                         mState = NotifiableStates.REGISTERED_WITH_USER;
@@ -457,7 +457,7 @@ public class NotifiableActivity extends AppCompatActivity {
                     }
 
                     @Override
-                    public void onError(String error) {
+                    public void onError(@NonNull String error) {
                         mSharedPrefs.edit().putInt(Constants.NOTIFIABLE_DEVICE_ID, -1).apply();
                         showSnackbar(error);
                     }
@@ -474,12 +474,12 @@ public class NotifiableActivity extends AppCompatActivity {
 
         NotifiableCallback<NotifiableDevice> notifiableCallback = new NotifiableCallback<NotifiableDevice>() {
             @Override
-            public void onSuccess(NotifiableDevice ret) {
+            public void onSuccess(@NonNull NotifiableDevice ret) {
                 showSnackbar("Updated device with id " + String.valueOf(ret.getId()));
             }
 
             @Override
-            public void onError(String error) {
+            public void onError(@NonNull String error) {
                 showSnackbar(error);
             }
         };
@@ -490,13 +490,13 @@ public class NotifiableActivity extends AppCompatActivity {
     private void updateDeviceName(final String name) {
         NotifiableCallback<NotifiableDevice> callback = new NotifiableCallback<NotifiableDevice>() {
             @Override
-            public void onSuccess(NotifiableDevice ret) {
+            public void onSuccess(@NonNull NotifiableDevice ret) {
                 mDeviceName = name;
                 showSnackbar("Updated device name to " + name);
             }
 
             @Override
-            public void onError(String error) {
+            public void onError(@NonNull String error) {
                 showSnackbar(error);
             }
         };
@@ -512,14 +512,14 @@ public class NotifiableActivity extends AppCompatActivity {
     private void updateDeviceLocale(final Locale locale) {
         NotifiableCallback<NotifiableDevice> callback = new NotifiableCallback<NotifiableDevice>() {
             @Override
-            public void onSuccess(NotifiableDevice ret) {
+            public void onSuccess(@NonNull NotifiableDevice ret) {
                 mCurrentLocale = locale;
 
                 showSnackbar("Updated device Locale to " + locale.getDisplayName());
             }
 
             @Override
-            public void onError(String error) {
+            public void onError(@NonNull String error) {
                 showSnackbar(error);
             }
         };
@@ -530,7 +530,7 @@ public class NotifiableActivity extends AppCompatActivity {
     private void unassignDevice() {
         mNotifiableManager.unassignDeviceFromUser(mDeviceName, mGcmToken, new NotifiableCallback<NotifiableDevice>() {
             @Override
-            public void onSuccess(NotifiableDevice ret) {
+            public void onSuccess(@NonNull NotifiableDevice ret) {
                 mState = NotifiableStates.REGISTERED_ANONYMOUSLY;
                 updateUi();
 
@@ -539,7 +539,7 @@ public class NotifiableActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onError(String error) {
+            public void onError(@NonNull String error) {
                 showSnackbar(error);
             }
         });
@@ -548,7 +548,7 @@ public class NotifiableActivity extends AppCompatActivity {
     private void assignDeviceToUser(@NonNull final String userName) {
         mNotifiableManager.assignDeviceToUser(userName, mDeviceName, mGcmToken, new NotifiableCallback<NotifiableDevice>() {
             @Override
-            public void onSuccess(NotifiableDevice ret) {
+            public void onSuccess(@NonNull NotifiableDevice ret) {
                 mDeviceUser = userName;
                 mState = NotifiableStates.REGISTERED_WITH_USER;
                 updateUi();
@@ -557,7 +557,7 @@ public class NotifiableActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onError(String error) {
+            public void onError(@NonNull String error) {
                 showSnackbar(error);
             }
         });
@@ -566,7 +566,7 @@ public class NotifiableActivity extends AppCompatActivity {
     private void unregisterDevice() {
         mNotifiableManager.unregisterDevice(String.valueOf(mDeviceId), new NotifiableCallback<Object>() {
             @Override
-            public void onSuccess(Object ret) {
+            public void onSuccess(@NonNull Object ret) {
                 mSharedPrefs.edit().putInt(Constants.NOTIFIABLE_DEVICE_ID, -1).apply();
 
                 // hide buttons
@@ -577,7 +577,7 @@ public class NotifiableActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onError(String error) {
+            public void onError(@NonNull String error) {
                 showSnackbar(error);
             }
         });

--- a/sample-app/src/main/java/com/futureworkshops/notifiable/sample/service/MyFirebaseMessagingService.java
+++ b/sample-app/src/main/java/com/futureworkshops/notifiable/sample/service/MyFirebaseMessagingService.java
@@ -16,6 +16,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Build.VERSION_CODES;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.support.annotation.RequiresApi;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.LocalBroadcastManager;
@@ -108,12 +109,12 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         mNotifiableManager.markNotificationReceived(String.valueOf(notification.getNotificationId()),
             String.valueOf(deviceId), new NotifiableCallback<Object>() {
                 @Override
-                public void onSuccess(Object ret) {
+                public void onSuccess(@NonNull Object ret) {
                     Log.d("NotificationService", "notification marked as received");
                 }
 
                 @Override
-                public void onError(String error) {
+                public void onError(@NonNull String error) {
                     Log.e("NotificationService", "Notification delivery error : " + error);
 
                 }


### PR DESCRIPTION
### :cop: Reviewers

@FWStelian @FWDiego @fwarisp 

### :pushpin: References
* **Issue:** #3 

### :tophat: What is the goal?
Annotate `NotifiableCallback` methods with `@NonNull` annotation to be coherent on the arguments sent by this callback method

### How is it being implemented?
Two methods of the `NotifiableCallback` have been annotated with the `@NonNull` annotation and checked all uses of those methods to be sure that no null values are sent.
I have removed unneeded null-checks on the received methods implementations 

### GIF

![](https://cdn-images-1.medium.com/max/1600/1*HKDA9edZZDTM1_OSIYtH3Q.jpeg)
