### PR TITLE
Hide okHttp logs on release

### DIFF
--- a/android_commons.gradle
+++ b/android_commons.gradle
@@ -16,7 +16,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-beta05'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-beta05'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         classpath 'com.google.gms:google-services:4.0.1'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 #
 # Copyright (c) 2018 Future Workshops. All rights reserved.
 #
-project.buildversion = 1.2
-project.buildnumber=3
+project.buildversion = 1.3
+project.buildnumber=4
 # Notifiable
 notifiable.server="YOUR_NOTIFIABLE_SERVER"
 notifiable.client="YOUR_NOTIFIABLE_CLIENT_ID"

--- a/library/src/main/java/com/futureworkshops/notifiable/networking/RestManager.java
+++ b/library/src/main/java/com/futureworkshops/notifiable/networking/RestManager.java
@@ -8,6 +8,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
+import com.futureworkshops.notifiable.BuildConfig;
 import com.futureworkshops.notifiable.LocaleParser;
 import com.futureworkshops.notifiable.Utils;
 import com.futureworkshops.notifiable.model.GenericResponse;
@@ -73,7 +74,11 @@ public class RestManager implements RestAPI {
         JavaNetCookieJar javaNetCookieJar = new JavaNetCookieJar(cookieManager);
 
         final HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
-        logging.setLevel(HttpLoggingInterceptor.Level.BODY);
+        if (BuildConfig.DEBUG) {
+            logging.setLevel(HttpLoggingInterceptor.Level.BODY);
+        } else {
+            logging.setLevel(HttpLoggingInterceptor.Level.NONE);
+        }
 
         final OkHttpClient okHttpClient = new OkHttpClient.Builder()
             .addInterceptor(new RequestInterceptor(clientSecret))


### PR DESCRIPTION
### :pushpin: References
Update version to hide the okHttp logs on release.

### :tophat: What is the goal?
When the version is release, the okHttp logs should be hidden.

### How is it being implemented?
1. Change the  `RestManager` to hide the logs on release
2. Update the library version
3. Update the gradle version

